### PR TITLE
Add units tests to signature verification

### DIFF
--- a/token-dispenser/programs/token-dispenser/src/ecosystems/secp256k1.rs
+++ b/token-dispenser/programs/token-dispenser/src/ecosystems/secp256k1.rs
@@ -1,9 +1,6 @@
 use {
     super::cosmos::CosmosPubkey,
-    crate::{
-        ErrorCode,
-        ProgramError::BorshIoError,
-    },
+    crate::ErrorCode,
     anchor_lang::{
         prelude::*,
         solana_program::{
@@ -16,6 +13,7 @@ use {
         AnchorSerialize,
     },
 };
+
 
 pub const SECP256K1_FULL_PREFIX: u8 = 0x04;
 pub const SECP256K1_ODD_PREFIX: u8 = 0x03;
@@ -177,6 +175,7 @@ pub fn secp256k1_sha256_verify_signer(
 }
 
 #[cfg(test)]
+use anchor_lang::prelude::ProgramError::BorshIoError;
 #[test]
 pub fn test_signature_verification() {
     let secp256k1_ix = Secp256k1InstructionData {

--- a/token-dispenser/programs/token-dispenser/src/lib.rs
+++ b/token-dispenser/programs/token-dispenser/src/lib.rs
@@ -424,7 +424,7 @@ impl IdentityCertificate {
                         &Secp256k1InstructionData::extract_message_and_check_signature(
                             &signature_verification_instruction,
                             pubkey,
-                            &verification_instruction_index,
+                            verification_instruction_index,
                         )?,
                     )?
                     .get_payload(),


### PR DESCRIPTION
Spent some more time on this to make sure it's right
- Add unit tests for the sec256k1 
- Improve the header checking