### PR TITLE
Add compute unit instruction

### DIFF
--- a/frontend/claim_sdk/solana.ts
+++ b/frontend/claim_sdk/solana.ts
@@ -8,6 +8,7 @@ import { MerkleTree } from './merkleTree'
 import {
   AddressLookupTableAccount,
   AddressLookupTableProgram,
+  ComputeBudgetProgram,
   Connection,
   Ed25519Program,
   LAMPORTS_PER_SOL,
@@ -357,6 +358,7 @@ export class TokenDispenserProvider {
       ])
       .instruction()
     ixs.push(claim_ix)
+    ixs.push(ComputeBudgetProgram.setComputeUnitLimit({ units: 200_000 }))
 
     const claimTx = new VersionedTransaction(
       new TransactionMessage({


### PR DESCRIPTION
This PR fixes a bug where Phantom adds extra instructions before the signature verification instruction, and that breaks the instruction since we rely on that instruction being the first.
By adding this compute units instructions ourselves, we trick phantom into not adding these extra instructions.