### PR TITLE
Fix is claimAlreadySubmitted

### DIFF
--- a/frontend/claim_sdk/solana.ts
+++ b/frontend/claim_sdk/solana.ts
@@ -127,9 +127,9 @@ export class TokenDispenserProvider {
 
   public async isClaimAlreadySubmitted(claimInfo: ClaimInfo): Promise<boolean> {
     return (
-      (await this.connection.getAccountInfo(
-        this.getReceiptPda(claimInfo)[0]
-      )) !== null
+      (
+        await this.connection.getAccountInfo(this.getReceiptPda(claimInfo)[0])
+      )?.owner.equals(this.programId) ?? false
     )
   }
 


### PR DESCRIPTION
The old way would fail when you airdrop sol into one of the receipt accounts