### PR TITLE
Don't throw error when already claimed for better error handling

### DIFF
--- a/frontend/claim_sdk/solana.ts
+++ b/frontend/claim_sdk/solana.ts
@@ -287,9 +287,6 @@ export class TokenDispenserProvider {
       )
 
     // 3. derive receipt pda
-    if (await this.isClaimAlreadySubmitted(claimInfo)) {
-      throw new Error('Claim already submitted')
-    }
     const receiptPda = this.getReceiptPda(claimInfo)[0]
 
     const lookupTableAccount = await this.getLookupTableAccount()


### PR DESCRIPTION
The frontend doesn't let you send the transactions if the claim has already been claimed. 

However, the frontend checks `isAlreadyClaimed` only once when it first loads the claim infos.
Therefore there's an edgecase where if someone else claims between the moment where the claims where loaded and the moment you actually sign and send the transaction, this will result in a failed transaction (that the frontend will handle).
But once you refresh, the claim will show as "already claimed" as expected.

The likelihood of the sequence of events is low anyway, so I'm OK with this edgecase.