### PR TITLE
disable image optimization

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -12,6 +12,7 @@ module.exports = {
       'cdn.discordapp.com',
       'raw.githubusercontent.com',
     ],
+    unoptimized: true,
   },
   swcMinify: false,
   env: {


### PR DESCRIPTION
we've hit over 100% of our image optimization plan with vercel (5000 images for our pro plan) and they charge $5 per 1000 images pay-as-you-go, right now we're at 14k ($20)

i'm monitoring the costs and if it gets out of hand we will have to deploy this to manage costs