### PR TITLE
Add `pub` Visibility Modifier To `ClaimCertificate`

### DIFF
--- a/token-dispenser/programs/token-dispenser/src/lib.rs
+++ b/token-dispenser/programs/token-dispenser/src/lib.rs
@@ -292,9 +292,9 @@ pub enum IdentityCertificate {
 
 #[derive(AnchorDeserialize, AnchorSerialize, Clone)]
 pub struct ClaimCertificate {
-    amount:             u64,
-    proof_of_identity:  IdentityCertificate,
-    proof_of_inclusion: MerklePath<SolanaHasher>, // Proof that the leaf is in the tree
+    pub amount:             u64,
+    pub proof_of_identity:  IdentityCertificate,
+    pub proof_of_inclusion: MerklePath<SolanaHasher>, // Proof that the leaf is in the tree
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# Overview

Adds the `pub` visibility modifier to all fields of the `ClaimCertificate` struct to allow the `token-dispenser` program to be imported by third-party libraries for programmatic claiming. Without this `token-dispenser` cant be inherited from directly due to the following 

```
field `proof_of_identity` of struct `ClaimCertificate` is private
field `amount` of struct `ClaimCertificate` is private
field `proof_of_inclusion` of struct `ClaimCertificate` is private
```