### PR TITLE
Add `pub` Visibility Modifier To `ClaimInfo` 

### DIFF
--- a/token-dispenser/programs/token-dispenser/src/lib.rs
+++ b/token-dispenser/programs/token-dispenser/src/lib.rs
@@ -238,8 +238,8 @@ pub struct Claim<'info> {
 
 #[derive(AnchorDeserialize, AnchorSerialize, Clone)]
 pub struct ClaimInfo {
-    identity: Identity,
-    amount:   u64,
+    pub identity: Identity,
+    pub amount:   u64,
 }
 
 /**


### PR DESCRIPTION
# Overview

Enables public visibility for `ClaimInfo` struct fields to allow for third party integrations.